### PR TITLE
feat: Allow custom dispatcher. Add first draft of CRUD dispatcher.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ This is a DSL wrapper around the ``okhttp`` [mockwebserver](https://github.com/s
 - Supports WebSockets
 - Supports String or Object bodies (which are serialized to JSON or YAML).
 - Supports SSL
+- CRUD mocking
 
 ### Creating a Mock Web Server
 
@@ -105,6 +106,31 @@ To support mock of web sockets this wrapper allows you to either specify a ``req
                     .waitFor(1500).andEmit("root - DELETED")
                 .done()
                 .once()
+
+### CRUD Mocking ###
+
+Often a rest API, will act like a CRUD (create, read, update & delete). So, it makes sense to have a different approach on setting expectations. 
+Instead of setting expectations for every single request, to take advantage of the crud nature of the API. This means that a get operation will return the resource, that has been previously created.
+In the same spirit a delete or update request, will act on a previously created resource and so on.
+
+To use CRUD mocking, the user will have to implement two interfaces:
+
+- An AttributeExtractor
+- A ResponseComposer
+
+The AttributeExtractor extracts attributes, from the path of the request and from the actual resource. Attributes is what is used to match paths to resources.
+In order to have a successful match, the path attributes need to be a subset of the actual resource attributes:
+The actual methods that need to be implemented are:
+
+    AttributeSet extract(String path);
+    AttributeSet extract(T object);
+
+
+Each get request, may result in one or more resources (based on the attributes, as explained above). To compose multiple resources into a single response, the ResponseComposer comes into play.
+The ResponseComposer is a simple object that specifies how multiple Strings can be composed into a single one:
+
+    String compose(Collection<String> items);
+
 
 #### More Examples ####
 

--- a/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
+++ b/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
@@ -20,6 +20,7 @@ import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.mockwebserver.internal.MockDispatcher;
 import io.fabric8.mockwebserver.internal.MockSSLContextFactory;
 import io.fabric8.mockwebserver.internal.MockServerExpectationImpl;
+import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -60,6 +61,14 @@ public class DefaultMockServer {
     this.server = server;
     this.responses = responses;
     this.server.setDispatcher(new MockDispatcher(responses));
+  }
+
+  public DefaultMockServer(Context context, MockWebServer server, Map<ServerRequest, Queue<ServerResponse>> responses, Dispatcher dispatcher, boolean useHttps) {
+    this.context = context;
+    this.useHttps = useHttps;
+    this.server = server;
+    this.responses = responses;
+    this.server.setDispatcher(dispatcher);
   }
 
   /**

--- a/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
@@ -1,0 +1,43 @@
+package io.fabric8.mockwebserver.crud;
+
+public class Attribute {
+
+    private final Key key;
+    private final Value value;
+
+
+    public Attribute(String key, String value) {
+        this(new Key(key), new Value(value));
+    }
+
+    public Attribute(Key key, Value value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public Key getKey() {
+        return key;
+    }
+
+    public Value getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Attribute attribute = (Attribute) o;
+
+        if (key != null ? !key.equals(attribute.key) : attribute.key != null) return false;
+        return value != null ? value.equals(attribute.value) : attribute.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
@@ -1,0 +1,8 @@
+package io.fabric8.mockwebserver.crud;
+
+public interface AttributeExtractor<T> {
+
+   AttributeSet extract(String path);
+
+    AttributeSet extract(T object);
+}

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
@@ -1,0 +1,67 @@
+package io.fabric8.mockwebserver.crud;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class AttributeSet {
+
+    private final Set<Attribute> attributes;
+
+
+    public static AttributeSet merge(AttributeSet... attributeSets) {
+        Set<Attribute> all = new LinkedHashSet<>();
+        for (AttributeSet f : attributeSets) {
+            all.addAll(f.attributes);
+        }
+        return new AttributeSet(all);
+    }
+
+    public AttributeSet(Attribute... attributes) {
+        this(Arrays.asList(attributes));
+    }
+
+    public AttributeSet(Collection<Attribute> attributes) {
+        this.attributes = attributes == null ? new LinkedHashSet<Attribute>() : new LinkedHashSet<>(attributes);
+    }
+
+    public AttributeSet add(Attribute... attr) {
+        Set<Attribute> all = new LinkedHashSet<>(attributes);
+        for(Attribute a : attr) {
+            all.add(a);
+        }
+        return new AttributeSet(all);
+    }
+
+    public boolean matches(AttributeSet candidate) {
+        for (Attribute c : candidate.attributes) {
+            boolean found = false;
+            for (Attribute a : attributes) {
+                if (c.equals(a)) {
+                    found = true;
+                }
+            }
+
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AttributeSet that = (AttributeSet) o;
+
+        return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return attributes != null ? attributes.hashCode() : 0;
+    }
+}

--- a/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
@@ -1,0 +1,124 @@
+package io.fabric8.mockwebserver.crud;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CrudDispatcher extends Dispatcher {
+
+    private static final String POST = "post";
+    private static final String UPDATE = "update";
+    private static final String GET = "get";
+    private static final String DELETE = "delete";
+
+    private Map<AttributeSet, String> map = new HashMap<>();
+
+    private final AttributeExtractor attributeExtractor;
+    private final ResponseComposer responseComposer;
+
+    public CrudDispatcher(AttributeExtractor attributeExtractor, ResponseComposer responseComposer) {
+        this.attributeExtractor = attributeExtractor;
+        this.responseComposer = responseComposer;
+    }
+
+    @Override
+    public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+        String path = request.getPath();
+        String method = request.getMethod();
+
+
+        if (POST.equalsIgnoreCase(method)) {
+            return handlePost(path, request.getBody().readUtf8());
+        } else if (UPDATE.equalsIgnoreCase(path)) {
+            return handlePost(path, request.getBody().readUtf8());
+        } else if (GET.equalsIgnoreCase(method)) {
+            return handleGet(path);
+        } else if (DELETE.equalsIgnoreCase(method)) {
+            return handleDelete(path);
+        }
+        return null;
+    }
+
+    /**
+     * Adds the specified object to the in-memory db.
+     *
+     * @param path
+     * @param s
+     * @return
+     */
+    public MockResponse handlePost(String path, String s) {
+        MockResponse response = new MockResponse();
+        AttributeSet features = AttributeSet.merge(attributeExtractor.extract(path), attributeExtractor.extract(s));
+        map.put(features, s);
+        response.setBody(s);
+        response.setResponseCode(202);
+        return response;
+    }
+
+     /**
+     * Updates the specified object to the in-memory db.
+     * @param path
+     * @param s
+     * @return
+     */
+    public MockResponse handleUpdate(String path, String s) {
+        return handlePost(path, s);
+    }
+
+    /**
+     * Performs a get for the corresponding object from the in-memory db.
+     *
+     * @param path The path.
+     * @return The {@link MockResponse}
+     */
+    public MockResponse handleGet(String path) {
+        MockResponse response = new MockResponse();
+        List<String> items = new ArrayList<>();
+        AttributeSet query = attributeExtractor.extract(path);
+
+        for (Map.Entry<AttributeSet, String> entry : map.entrySet()) {
+            if (entry.getKey().matches(query)) {
+                items.add(entry.getValue());
+            }
+        }
+        if (!items.isEmpty()) {
+            response.setBody(responseComposer.compose(items));
+            response.setResponseCode(200);
+        } else {
+            response.setResponseCode(404);
+        }
+        return response;
+    }
+
+
+    /**
+     * Performs a delete for the corresponding object from the in-memory db.
+     * @param path
+     * @return
+     */
+    public MockResponse handleDelete(String path) {
+        MockResponse response = new MockResponse();
+        List<AttributeSet> items = new ArrayList<>();
+        AttributeSet query = attributeExtractor.extract(path);
+
+        for (Map.Entry<AttributeSet, String> entry : map.entrySet()) {
+            if (entry.getKey().matches(query)) {
+                items.add(entry.getKey());
+            }
+        }
+        if (!items.isEmpty()) {
+            for (AttributeSet item: items)  {
+                map.remove(item);
+            }
+            response.setResponseCode(200);
+        } else {
+            response.setResponseCode(404);
+        }
+        return response;
+    }
+}

--- a/src/main/java/io/fabric8/mockwebserver/crud/Key.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Key.java
@@ -1,0 +1,30 @@
+package io.fabric8.mockwebserver.crud;
+
+public class Key {
+
+    private final String name;
+
+    public Key(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Key key = (Key) o;
+
+        return name != null ? name.equals(key.name) : key.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+}

--- a/src/main/java/io/fabric8/mockwebserver/crud/ResponseComposer.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/ResponseComposer.java
@@ -1,0 +1,8 @@
+package io.fabric8.mockwebserver.crud;
+
+import java.util.Collection;
+
+public interface ResponseComposer {
+
+    String compose(Collection<String> items);
+}

--- a/src/main/java/io/fabric8/mockwebserver/crud/Value.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Value.java
@@ -1,0 +1,39 @@
+package io.fabric8.mockwebserver.crud;
+
+public class Value {
+
+    private static final String ANY = "*";
+
+    private final String value;
+
+    public Value(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (ANY.equals(value)) {
+            return true;
+        }
+
+        Value key = (Value) o;
+
+        if (ANY.equals(key.value)) {
+            return true;
+        }
+        return value != null ? value.equals(key.value) : key.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/curd/AttributeSetTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/curd/AttributeSetTest.groovy
@@ -1,0 +1,57 @@
+/*
+ *   Copyright (C) 2016 Red Hat, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.fabric8.mockwebserver.crud
+
+import spock.lang.Specification
+
+class AttributeTest extends Specification {
+
+    def "when two feature set are empty the should be equals"() {
+        given:
+        when:
+        AttributeSet f1 = new AttributeSet()
+        AttributeSet f2 = new AttributeSet()
+        then:
+        assert f1.equals(f2)
+    }
+
+    def "when two feature sets contain the same feature"() {
+        given:
+        Attribute f = new Attribute("key1", "value1")
+        when:
+        AttributeSet f1 = new AttributeSet(f)
+        AttributeSet f2 = new AttributeSet(f)
+        then:
+        assert f1.equals(f2)
+    }
+
+    def "when two feature sets contain the same features order should not matter"() {
+        given:
+        Attribute f1 = new Attribute("key1", "value1")
+        Attribute f2 = new Attribute("key2", "value2")
+        Attribute f3 = new Attribute("key3", "value3")
+        when:
+        AttributeSet fs12 = new AttributeSet(f1, f2)
+        AttributeSet fs21 = new AttributeSet(f2, f1)
+        AttributeSet fs23 = new AttributeSet(f2, f3)
+
+        then:
+        assert fs12.equals(fs21)
+        assert !fs12.equals(fs23)
+        assert !fs21.equals(fs23)
+    }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/curd/AttributeTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/curd/AttributeTest.groovy
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (C) 2016 Red Hat, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.fabric8.mockwebserver.crud
+
+import spock.lang.Specification
+
+class AttributeSetTest extends Specification {
+
+    def "when key and value equals features should equal"() {
+        given:
+        when:
+        Attribute f11 = new Attribute("key1", "value1")
+        Attribute f11a = new Attribute("key1", "value1")
+        Attribute f12 = new Attribute("key1", "value2")
+        Attribute f22 = new Attribute("key2", "value2")
+
+        then:
+        assert !f11.equals(f22)
+        assert !f11.equals(f12)
+        assert f11.equals(f11a)
+    }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/curd/CrudDispatcherTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/curd/CrudDispatcherTest.groovy
@@ -1,0 +1,99 @@
+/*
+ *   Copyright (C) 2016 Red Hat, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.fabric8.mockwebserver.crud
+
+import io.fabric8.mockwebserver.Context
+import io.fabric8.mockwebserver.DefaultMockServer
+import io.fabric8.mockwebserver.ServerRequest
+import io.fabric8.mockwebserver.ServerResponse
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.RequestBody
+import okhttp3.MediaType
+import okhttp3.mockwebserver.MockWebServer
+import spock.lang.Specification
+
+class CrudDispatcherTest extends Specification {
+
+    AttributeExtractor extractor = new AttributeExtractor() {
+
+        @Override
+        AttributeSet extract(String path) {
+            AttributeSet set = new AttributeSet()
+
+            String[] parts = path.split("/")
+            if (parts.length > 2) {
+                set = set.add(new Attribute("namespace", parts[2]))
+            }
+
+            if (parts.length > 4) {
+                set = set.add(new Attribute("name", parts[4]))
+            }
+            return set
+        }
+
+        @Override
+        AttributeSet extract(Object object) {
+            return null
+        }
+    }
+
+    ResponseComposer composer = new ResponseComposer() {
+        @Override
+        String compose(Collection<String> items) {
+            StringBuilder sb = new StringBuilder();
+            for (String item : items) {
+                sb.append(item).append(" ")
+            }
+            return sb.toString().trim()
+        }
+    }
+
+    def "should be able to get after a post"() {
+        given:
+        DefaultMockServer server = new DefaultMockServer(new Context(), new  MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new CrudDispatcher(extractor, composer), false)
+        when:
+        server.start()
+        then:
+        OkHttpClient client = new OkHttpClient()
+        Request post = new Request.Builder().post(RequestBody.create(MediaType.parse("text/html"), "one")).url(server.url("/namespace/test/name/one")).build()
+        client.newCall(post).execute()
+        Request get = new Request.Builder().get().url(server.url("/namespace/test/name/one")).build()
+        Response response = client.newCall(get).execute()
+        assert response.body().string().equals("one")
+    }
+
+    def "should be able to delete after a post"() {
+        given:
+        DefaultMockServer server = new DefaultMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new CrudDispatcher(extractor, composer), false)
+        when:
+        server.start()
+        then:
+        OkHttpClient client = new OkHttpClient()
+        Request post = new Request.Builder().post(RequestBody.create(MediaType.parse("text/html"), "one")).url(server.url("/namespace/test/name/one")).build()
+        client.newCall(post).execute()
+        Request get = new Request.Builder().delete().url(server.url("/namespace/test/name/one")).build()
+        Response response = client.newCall(get).execute()
+        assert response.successful
+
+        Request getMissing = new Request.Builder().delete().url(server.url("/namespace/test/name/two")).build()
+        Response responseMissing = client.newCall(getMissing).execute()
+    assert !responseMissing.successful
+    }
+
+}


### PR DESCRIPTION
This pull request adds a new feature which is the crud dispatcher. The crud dispatcher allows the mock webserver to act as a CRUD. So, instead of setting expectations for every single request, it works as an in memory crud, for storing, reading, updating and deleting resources.

It requires an object that will act as a mapper from paths to resources and vice versa and also an object that helps aggregating resources.