### PR TITLE
Support custom ExecutorService and more friendly DSL

### DIFF
--- a/src/main/java/io/fabric8/mockwebserver/dsl/Eventable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Eventable.java
@@ -22,4 +22,6 @@ public interface Eventable<T> {
 
     Emitable<T> waitFor(long millis);
 
+    Emitable<T> immediately();
+
 }

--- a/src/main/java/io/fabric8/mockwebserver/dsl/WebSocketable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/WebSocketable.java
@@ -16,8 +16,12 @@
 
 package io.fabric8.mockwebserver.dsl;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 public interface WebSocketable<T> {
 
   T andUpgradeToWebSocket();
+
+  T andUpgradeToWebSocket(ScheduledExecutorService executor);
 
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
@@ -30,30 +30,40 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder<T>, EventDoneable<T> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public InlineWebSocketSessionBuilder(Context context, Function<WebSocketSession, T> function) {
-        this.context = context;
-        this.function = function;
-    }
-
+    private final ScheduledExecutorService executor;
     private final Context context;
     private final Function<WebSocketSession, T> function;
     private WebSocketSession session;
 
+    public InlineWebSocketSessionBuilder(Context context, ScheduledExecutorService executor, Function<WebSocketSession, T> function) {
+        this.context = context;
+        this.function = function;
+        this.executor = executor;
+    }
+
+    public InlineWebSocketSessionBuilder(Context context, Function<WebSocketSession, T> function) {
+        this.context = context;
+        this.function = function;
+        this.executor = Executors.newSingleThreadScheduledExecutor();
+    }
+
     @Override
     public EventDoneable<T> open(Object... response) {
-        this.session = new WebSocketSession(context, toWebSocketMessages(response), null, null);
+        this.session = new WebSocketSession(context, executor, toWebSocketMessages(response), null, null);
         return this;
     }
 
 
     @Override
     public T failure(Object response, Exception e) {
-        return function.apply(new WebSocketSession(context, Collections.<WebSocketMessage>emptyList(), toWebSocketMessage(response), e));
+        return function.apply(new WebSocketSession(context, executor, Collections.<WebSocketMessage>emptyList(), toWebSocketMessage(response), e));
     }
 
     @Override

--- a/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
@@ -102,6 +102,11 @@ public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder
         };
     }
 
+    @Override
+    public Emitable<EventDoneable<T>> immediately() {
+        return waitFor(0);
+    }
+
     private List<WebSocketMessage> toWebSocketMessages(Object... messages) {
         List<WebSocketMessage> response = new ArrayList<>();
         for (Object msg : messages) {

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,7 @@ public class WebSocketSession extends WebSocketListener {
     private final List<WebSocketMessage> timedEvents = new ArrayList<>();
 
     private final AtomicReference<WebSocket> webSocketRef = new AtomicReference<>();
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executor;
 
     private final Context context;
 
@@ -54,11 +55,12 @@ public class WebSocketSession extends WebSocketListener {
         webSocketRef.get().close(code, reason);
     }
 
-    public WebSocketSession(Context context, List<WebSocketMessage> open, WebSocketMessage failure, Exception cause) {
+    public WebSocketSession(Context context, ScheduledExecutorService executor, List<WebSocketMessage> open, WebSocketMessage failure, Exception cause) {
         this.context = context;
         this.open = open;
         this.failure = failure;
         this.cause = cause;
+        this.executor = executor;
     }
 
     @Override


### PR DESCRIPTION
Hi, in this pull request I added the new method `immediately ()` as a shorted form of `waitFor (0)`. Also added support custom ExecutroService for WebSocket if has a need to run WebSocket on a custom thread.