### PR TITLE
Chore: upgrade okhttp to 3.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,11 @@
     </distributionManagement>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Dependencies -->
-        <okhttp.version>3.12.0</okhttp.version>
+        <okhttp.version>3.12.1</okhttp.version>
         <jackson.version>2.9.8</jackson.version>
         <sundrio.version>0.13.1</sundrio.version>
         <zjsonpatch.version>0.3.0</zjsonpatch.version>


### PR DESCRIPTION
It seems like there was some bug in 3.12.0 due to which we
were getting NoSuchMethod errors in kubernetes-client, so upgrading to 3.12.1 which seems
to resolve this issue.

#27 