### PR TITLE
WebSocket API extended

### DIFF
--- a/src/main/java/io/fabric8/mockwebserver/dsl/InputMatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/InputMatcher.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver.dsl;
+
+@FunctionalInterface
+public interface InputMatcher {
+    boolean matches(Object input);
+}

--- a/src/main/java/io/fabric8/mockwebserver/dsl/ResponseProducer.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/ResponseProducer.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.mockwebserver.dsl;
+
+import io.fabric8.mockwebserver.dsl.Function;
+import io.fabric8.mockwebserver.internal.WebSocketMessage;
+
+@FunctionalInterface
+public interface ResponseProducer extends Function<String, WebSocketMessage> {
+}


### PR DESCRIPTION
Extended with none-string input message matcher. Extended with none-string emitter.
Dynamic matchers and response producers are possible while old string->string matching preserved