### PR TITLE
New Web socket features: expect an http request and expect a sent soc…

### DIFF
--- a/src/main/java/io/fabric8/mockwebserver/dsl/Eventable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Eventable.java
@@ -20,6 +20,10 @@ public interface Eventable<T> {
 
     Emitable<TimesOrOnceable<T>> expect(Object in);
 
+    Emitable<TimesOrOnceable<T>> expectHttpRequest(final String path);
+
+    Emitable<TimesOrOnceable<T>> expectSentWebSocketMessage(final Object in);
+
     Emitable<T> waitFor(long millis);
 
     Emitable<T> immediately();


### PR DESCRIPTION
added new features for webSocket API:
`server.expect().get().withPath("/api/v1/users/watch")
                .andUpgradeToWebSocket()
                .open()
                .expectHttpRequest("/api/v1/create").andEmit("CREATED").once()
                .expectSentWebSocketMessage("CREATED").andEmit("DELETED").once()
                .done()
                .once()`

When using expectHttpRequest we are using a normal httpRequest as the trigger to send a response through the socket.
When using expectSentWebSocketMessage we are using a message received through the socket to send a response (this way we can send multiple messages through the socket).
In the example when receiving a GET/POST/PUT/DELETE etc at "/api/v1/create" endpoint we will send through the web socket "CREATED" and just before "DELETED". #37 