### PR TITLE
Adding argument to getStatusCode

### DIFF
--- a/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
@@ -67,7 +67,7 @@ public class ChunkedResponse implements ServerResponse {
         MockResponse mockResponse = new MockResponse();
         mockResponse.setHeaders(bodyProvider.getHeaders());
         mockResponse.setChunkedBody(concatBody(request), DEFAULT_MAX_CHUNK_SIZE);
-        mockResponse.setResponseCode(bodyProvider.getStatusCode());
+        mockResponse.setResponseCode(bodyProvider.getStatusCode(request));
 
         if (responseDelay > 0) {
             mockResponse.setBodyDelay(responseDelay, responseDelayUnit);

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
@@ -311,8 +311,8 @@ public class MockServerExpectationImpl implements MockServerExpectation {
       }
 
       @Override
-      public int getStatusCode() {
-        return provider.getStatusCode();
+      public int getStatusCode(RecordedRequest request) {
+        return provider.getStatusCode(request);
       }
 
       @Override
@@ -340,8 +340,8 @@ public class MockServerExpectationImpl implements MockServerExpectation {
       }
 
       @Override
-      public int getStatusCode() {
-        return provider.getStatusCode();
+      public int getStatusCode(RecordedRequest request) {
+        return provider.getStatusCode(request);
       }
 
       @Override

--- a/src/main/java/io/fabric8/mockwebserver/internal/SimpleResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/SimpleResponse.java
@@ -67,7 +67,7 @@ public class SimpleResponse implements ServerResponse {
   public MockResponse toMockResponse(RecordedRequest request) {
     MockResponse mockResponse = new MockResponse();
     mockResponse.setHeaders(bodyProvider.getHeaders());
-    mockResponse.setResponseCode(bodyProvider.getStatusCode());
+    mockResponse.setResponseCode(bodyProvider.getStatusCode(request));
 
     if (webSocketSession != null) {
       mockResponse.withWebSocketUpgrade(webSocketSession);

--- a/src/main/java/io/fabric8/mockwebserver/utils/ResponseProvider.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/ResponseProvider.java
@@ -16,13 +16,14 @@
 package io.fabric8.mockwebserver.utils;
 
 import okhttp3.Headers;
+import okhttp3.mockwebserver.RecordedRequest;
 
 /**
  * A class that allows returning a response given a certain request.
  */
 public interface ResponseProvider<T> extends BodyProvider<T> {
 
-    int getStatusCode();
+    int getStatusCode(RecordedRequest request);
 
     Headers getHeaders();
 

--- a/src/main/java/io/fabric8/mockwebserver/utils/ResponseProviders.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/ResponseProviders.java
@@ -56,7 +56,7 @@ public class ResponseProviders {
                 private Headers headers = new Headers.Builder().build();
 
                 @Override
-                public int getStatusCode() {
+                public int getStatusCode(RecordedRequest request) {
                     return statusCode;
                 }
 
@@ -111,7 +111,7 @@ public class ResponseProviders {
         }
 
         @Override
-        public int getStatusCode() {
+        public int getStatusCode(RecordedRequest request) {
             return statusCode;
         }
 

--- a/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
@@ -361,7 +361,7 @@ class DefaultMockServerTest extends Specification {
         server.expect().get().withPath("/api/v1/users").andReply(new ResponseProvider<Object>() {
             private Headers headers = new Headers.Builder().build()
 
-            int getStatusCode() {
+            int getStatusCode(RecordedRequest request) {
                 return 200 + (counter[0]++)
             }
 


### PR DESCRIPTION
Adding argument to getStatusCode otherwise test configurations like [this one](https://github.com/apache/camel/blob/d6c7fb022869be1a29636284fe49e93d41735b3b/components/camel-kubernetes/src/test/java/org/apache/camel/component/kubernetes/cluster/utils/LockTestServer.java#L66-L86) become impossible.

cc: @rohanKanojia , @oscerd 