### PR TITLE
Fix the attribute selector logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 #### Bugs
 
 #### Improvements
-
+* AttributeSet now examines all attributes when determining if another AttributeSet matches.
 #### Dependency Upgrade
 
 #### New Feature

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
@@ -7,7 +7,8 @@ import java.util.Map;
 
 public class AttributeSet {
 
-    private final Map<Key, Attribute> attributes;
+    // Package-private for testing
+    final Map<Key, Attribute> attributes;
 
     public static AttributeSet merge(AttributeSet... attributeSets) {
         Map<Key, Attribute> all = new HashMap<>();

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
@@ -67,20 +67,23 @@ public class AttributeSet {
      * @return match
      */
     public boolean matches(AttributeSet candidate) {
-        for (Attribute c : candidate.attributes.values()) {
-            switch (c.getType()) {
-                case EXISTS:
-                    return attributes.containsKey(c.getKey());
-                case NOT_EXISTS:
-                    return !attributes.containsKey(c.getKey());
-                case WITHOUT:
-                    return !attributes.containsValue(c);
-                case WITH:
-                default:
-                    return attributes.containsValue(c);
-            }
+        return candidate.attributes.values()
+            .stream()
+            .allMatch(this::satisfiesAttribute);
+    }
+
+    private boolean satisfiesAttribute(Attribute c) {
+        switch (c.getType()) {
+            case EXISTS:
+                return attributes.containsKey(c.getKey());
+            case NOT_EXISTS:
+                return !attributes.containsKey(c.getKey());
+            case WITHOUT:
+                return !attributes.containsValue(c);
+            case WITH:
+            default:
+                return attributes.containsValue(c);
         }
-        return true;
     }
 
     @Override

--- a/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
@@ -60,10 +60,10 @@ class AttributeTest extends Specification {
         Attribute a1 = new Attribute("key1", "", AttributeType.EXISTS)
         Attribute a2 = new Attribute("key2", "value2")
         when:
-        AttributeSet f1 = new AttributeSet(a1, a2)
-        AttributeSet f2 = new AttributeSet(a1, a2)
+        AttributeSet selector = new AttributeSet(a1, a2)
+        AttributeSet attributeSet = new AttributeSet(a1, a2)
         then:
-        assert f2.matches(f1)
+        assert attributeSet.matches(selector)
     }
 
     def "when an EXISTS attribute exists in one set but not the other sets they should not match"() {
@@ -71,10 +71,10 @@ class AttributeTest extends Specification {
         Attribute a1 = new Attribute("key1", "", AttributeType.EXISTS)
         Attribute a2 = new Attribute("key2", "value2")
         when:
-        AttributeSet f1 = new AttributeSet(a1, a2)
-        AttributeSet f2 = new AttributeSet(a2)
+        AttributeSet selector = new AttributeSet(a1, a2)
+        AttributeSet attributeSet = new AttributeSet(a2)
         then:
-        assert !f2.matches(f1)
+        assert !attributeSet.matches(selector)
     }
 
     def "when a NOT_EXISTS attribute exists in both sets they should not match"() {
@@ -82,10 +82,10 @@ class AttributeTest extends Specification {
         Attribute a1 = new Attribute("key1", "", AttributeType.NOT_EXISTS)
         Attribute a2 = new Attribute("key2", "value2")
         when:
-        AttributeSet f1 = new AttributeSet(a1, a2)
-        AttributeSet f2 = new AttributeSet(a1, a2)
+        AttributeSet selector = new AttributeSet(a1, a2)
+        AttributeSet attributeSet = new AttributeSet(a1, a2)
         then:
-        assert !f2.matches(f1)
+        assert !attributeSet.matches(selector)
     }
 
     def "when a NOT_EXISTS attribute exists in one set but not the other sets they should match"() {
@@ -93,9 +93,28 @@ class AttributeTest extends Specification {
         Attribute a1 = new Attribute("key1", "", AttributeType.NOT_EXISTS)
         Attribute a2 = new Attribute("key2", "value2")
         when:
-        AttributeSet f1 = new AttributeSet(a1, a2)
-        AttributeSet f2 = new AttributeSet(a2)
+        AttributeSet selector = new AttributeSet(a1, a2)
+        AttributeSet attributeSet = new AttributeSet(a2)
         then:
-        assert f2.matches(f1)
+        assert attributeSet.matches(selector)
     }
+
+  def "when multiple attributes are specified it should examine all"() {
+    given:
+    // Naming is important here as it controls the hashed order
+    Attribute a2 = new Attribute("key2", "value2")
+    Attribute a3 = new Attribute("key3", "", AttributeType.EXISTS)
+    when:
+    AttributeSet attributeSet = new AttributeSet(a2)
+    AttributeSet selectorWithOne = new AttributeSet(a2)
+    AttributeSet selectorWithTwo = new AttributeSet(a2, a3);
+    then:
+
+    // Assert that the order is suitable for testing. The failing attribute should
+    // be in the *second* position to ensure we're examining all the values of the selector
+    assert new ArrayList<>(selectorWithTwo.attributes.values()).indexOf(a3) == 1;
+
+    assert attributeSet.matches(selectorWithOne)
+    assert !attributeSet.matches(selectorWithTwo)
+  }
 }


### PR DESCRIPTION
The AttributeSet matching logic has a bug in it, introduced in #41. The use of returns in the function body meant that only the first candidate attribute was being examined, and that was used as the result for the entire method.

If the hashing worked out such that the first candidate matched, but the second didn't, `matches` would improperly return true.

This adds a test for that case and fixes the bug.