### PR TITLE
OkHttp 4.9.0 version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- Dependencies -->
-    <okhttp.version>3.12.12</okhttp.version>
+    <okhttp.version>4.9.0</okhttp.version>
     <jackson.version>2.10.4</jackson.version>
     <sundrio.version>0.21.0</sundrio.version>
     <zjsonpatch.version>0.3.0</zjsonpatch.version>

--- a/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
@@ -188,7 +188,7 @@ class DefaultMockServerTest extends Specification {
         closed.await(10, TimeUnit.SECONDS)
     }
 
-    def "when setting a request/response websocket message it should be fired when the event is triggered"() {
+    def "when setting a request or response websocket message it should be fired when the event is triggered"() {
         given:
         CountDownLatch opened = new CountDownLatch(1)
         CountDownLatch closed = new CountDownLatch(1)
@@ -416,7 +416,7 @@ class DefaultMockServerTest extends Specification {
         }
     }
 
-    def "when setting an httprequest/response websocket message it should be fired when the event is triggered"() {
+    def "when setting an httprequest or response websocket message it should be fired when the event is triggered"() {
         given:
         CountDownLatch opened = new CountDownLatch(1)
         CountDownLatch closed = new CountDownLatch(1)
@@ -491,7 +491,7 @@ class DefaultMockServerTest extends Specification {
         closed.await(10, TimeUnit.SECONDS)
     }
 
-    def "when setting an sentWebSocketMessage/response websocket message it should be fired when the event is triggered"() {
+    def "when setting an sentWebSocketMessage or response websocket message it should be fired when the event is triggered"() {
         given:
         CountDownLatch opened = new CountDownLatch(1)
         CountDownLatch closed = new CountDownLatch(1)


### PR DESCRIPTION
Note: removed slashes from method name to avoid 'illegal method name' errors, see: https://issues.apache.org/jira/browse/GROOVY-8795

See #53