### PR TITLE
Major project refactor and clean-up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
     - checkout
     - run:
+        name: License check
+        command: mvn -N license:check
+    - run:
         command: |
           mvn clean install
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,17 @@
 #
-# Copyright 2016 Red Hat, Inc.
+# Copyright (C) 2015 Red Hat, Inc.
 #
-# Red Hat licenses this file to you under the Apache License, version
-# 2.0 (the "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#         http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.  See the License for the specific language governing
-# permissions and limitations under the License.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2015 Red Hat, Inc.
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+    Copyright (C) 2015 Red Hat, Inc.
 
-          http://www.apache.org/licenses/LICENSE-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/main/java/io/fabric8/mockwebserver/Context.java
+++ b/src/main/java/io/fabric8/mockwebserver/Context.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
+++ b/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
@@ -104,7 +104,7 @@ public class DefaultMockServer {
       startInternal();
       server.start();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new MockServerException("Exception when starting DefaultMockServer", e);
     }
   }
 
@@ -113,7 +113,7 @@ public class DefaultMockServer {
       startInternal();
       server.start(port);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new MockServerException("Exception when starting DefaultMockServer with port", e);
     }
   }
 
@@ -122,7 +122,7 @@ public class DefaultMockServer {
       startInternal();
       server.start(inetAddress, port);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new MockServerException("Exception when starting DefaultMockServer with InetAddress and port", e);
     }
   }
 
@@ -130,7 +130,7 @@ public class DefaultMockServer {
     try {
       server.shutdown();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new MockServerException("Exception when stopping DefaultMockServer", e);
     } finally {
       shutdownInternal();
     }

--- a/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
+++ b/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
@@ -44,11 +44,11 @@ public class DefaultMockServer {
   private final AtomicBoolean shutdown = new AtomicBoolean();
 
   public DefaultMockServer() {
-    this(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), false);
+    this(new Context(), new MockWebServer(), new HashMap<>(), false);
   }
 
   public DefaultMockServer(boolean useHttps) {
-    this(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), useHttps);
+    this(new Context(), new MockWebServer(), new HashMap<>(), useHttps);
   }
 
   public DefaultMockServer(MockWebServer server, Map<ServerRequest, Queue<ServerResponse>> responses, boolean useHttps) {
@@ -81,7 +81,6 @@ public class DefaultMockServer {
    * This method is called right after shutdown. Override it to add extra cleanup.
    */
   public void onShutdown() {
-
   }
 
 

--- a/src/main/java/io/fabric8/mockwebserver/MockServer.java
+++ b/src/main/java/io/fabric8/mockwebserver/MockServer.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver;
+
+import io.fabric8.mockwebserver.dsl.MockServerExpectation;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
+
+public interface MockServer {
+
+  /**
+   * This method is called right before start. Override it to add extra initialization.
+   */
+  default void onStart() {
+  }
+
+  /**
+   * This method is called right after shutdown. Override it to add extra cleanup.
+   */
+  default void onShutdown() {
+  }
+
+  /**
+   * The port for the {@link okhttp3.mockwebserver.MockWebServer}.
+   *
+   * @return the MockWebServer port.
+   */
+  int getPort();
+
+  /**
+   * The host name for the {@link okhttp3.mockwebserver.MockWebServer}.
+   * @return the MockWebServer host name;
+   */
+  String getHostName();
+
+  /**
+   * Returns a {@link Proxy} for the {@link okhttp3.mockwebserver.MockWebServer} with the current HostName and Port.
+   *
+   * @return a Proxy for the MockWebServer.
+   */
+  Proxy toProxyAddress();
+
+  /**
+   * Returns a String URL for connecting to this server.
+   *
+   * @param path the request path, such as "/".
+   */
+  String url(String path);
+
+  /**
+   * Returns a {@link MockServerExpectation} to set the expectations.
+   *
+   * @return the MockServerExpectation builder.
+   */
+  MockServerExpectation expect();
+
+  /**
+   * Returns the number of HTTP requests received thus far by this server. This may exceed the
+   * number of HTTP connections when connection reuse is in practice.
+   */
+  int getRequestCount();
+
+  /**
+   * Awaits the next HTTP request, removes it, and returns it. Callers should use this to verify the
+   * request was sent as intended. This method will block until the request is available, possibly
+   * forever.
+   *
+   * @return the head of the request queue
+   */
+  RecordedRequest takeRequest() throws InterruptedException;
+
+  /**
+   * Awaits the next HTTP request (waiting up to the specified wait time if necessary), removes it,
+   * and returns it. Callers should use this to verify the request was sent as intended within the
+   * given time.
+   *
+   * @param timeout how long to wait before giving up, in units of {@code unit}
+   * @param unit a {@code TimeUnit} determining how to interpret the {@code timeout} parameter
+   * @return the head of the request queue
+   */
+  RecordedRequest takeRequest(long timeout, TimeUnit unit) throws InterruptedException;
+
+  /**
+   * Returns the last (most recent) HTTP request processed by the {@link okhttp3.mockwebserver.MockWebServer}.
+   *
+   * n.b. This method clears the request queue.
+   *
+   * @return the most recent RecordedRequest or null if none was processed.
+   */
+  RecordedRequest getLastRequest() throws InterruptedException;
+}

--- a/src/main/java/io/fabric8/mockwebserver/MockServerException.java
+++ b/src/main/java/io/fabric8/mockwebserver/MockServerException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver;
+
+public class MockServerException extends RuntimeException {
+
+  private static final long serialVersionUID = 2158577731194403856L;
+
+  public MockServerException(String message) {
+    super(message);
+  }
+
+  public MockServerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/io/fabric8/mockwebserver/MockServerException.java
+++ b/src/main/java/io/fabric8/mockwebserver/MockServerException.java
@@ -26,4 +26,36 @@ public class MockServerException extends RuntimeException {
   public MockServerException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  /**
+   * Wraps the provided {@link Throwable} in a MockServerException in case it's checked exception.
+   *
+   * <p> For RuntimeException instances, the original exception is returned.
+   *
+   * @param cause Throwable to wrap.
+   * @return the original exception in case it's unchecked, or a MockServerException wrapping it.
+   */
+  public static RuntimeException launderThrowable(Throwable cause) {
+    return launderThrowable("An error has occurred.", cause);
+  }
+
+  /**
+   * Wraps the provided {@link Throwable} in a MockServerException in case it's checked exception.
+   *
+   * <p> For RuntimeException instances, the original exception is returned.
+   *
+   * @param message Message to use for the exception.
+   * @param cause Throwable to wrap.
+   * @return the original exception in case it's unchecked, or a MockServerException wrapping it.
+   */
+  public static RuntimeException launderThrowable(String message, Throwable cause) {
+    if (cause instanceof RuntimeException) {
+      return (RuntimeException) cause;
+    } else if (cause instanceof Error) {
+      throw (Error) cause;
+    } else if (cause instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+    }
+    throw new MockServerException(message , cause);
+  }
 }

--- a/src/main/java/io/fabric8/mockwebserver/ServerRequest.java
+++ b/src/main/java/io/fabric8/mockwebserver/ServerRequest.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver;
 
 public interface ServerRequest {

--- a/src/main/java/io/fabric8/mockwebserver/ServerResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/ServerResponse.java
@@ -23,8 +23,5 @@ public interface ServerResponse {
 
     boolean isRepeatable();
 
-    @Deprecated
-    MockResponse toMockResponse();
-
     MockResponse toMockResponse(RecordedRequest recordedRequest);
 }

--- a/src/main/java/io/fabric8/mockwebserver/ServerResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/ServerResponse.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver;
 
 import okhttp3.mockwebserver.MockResponse;

--- a/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 import java.util.Objects;

--- a/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
@@ -1,5 +1,7 @@
 package io.fabric8.mockwebserver.crud;
 
+import java.util.Objects;
+
 import static io.fabric8.mockwebserver.crud.AttributeType.WITH;
 
 public class Attribute {
@@ -38,18 +40,13 @@ public class Attribute {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         Attribute attribute = (Attribute) o;
-
-        if (key != null ? !key.equals(attribute.key) : attribute.key != null) return false;
-        return value != null ? value.equals(attribute.value) : attribute.value == null;
+        return Objects.equals(key, attribute.key) && Objects.equals(value, attribute.value) && type == attribute.type;
     }
 
     @Override
     public int hashCode() {
-        int result = key != null ? key.hashCode() : 0;
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        return result;
+        return Objects.hash(key, value, type);
     }
 
     @Override

--- a/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
@@ -8,13 +8,12 @@ public class Attribute {
     private final Value value;
     private final AttributeType type;
 
-
     public Attribute(Key key, Value value, AttributeType type) {
-    	this.key = key;
-    	this.value = value;
-    	this.type = type;
+        this.key = key;
+        this.value = value;
+        this.type = type;
     }
-    
+
     public Attribute(String key, String value, AttributeType type) {
     	this(new Key(key), new Value(value), type);
     }
@@ -24,9 +23,8 @@ public class Attribute {
     }
 
     public Attribute(String key, String value) {
-    	this(new Key(key), new Value(value));
+        this(new Key(key), new Value(value));
     }
-    
 
     public Key getKey() {
         return key;

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 public interface AttributeExtractor {

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
@@ -2,13 +2,6 @@ package io.fabric8.mockwebserver.crud;
 
 public interface AttributeExtractor<T> {
 
-    @Deprecated //to be replaced with fromPath
-    AttributeSet extract(String path);
-
-    @Deprecated //to be replaced with fromResource.
-    AttributeSet extract(T object);
-
-
     AttributeSet fromPath(String path);
 
     AttributeSet fromResource(String resource);

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeExtractor.java
@@ -1,6 +1,6 @@
 package io.fabric8.mockwebserver.crud;
 
-public interface AttributeExtractor<T> {
+public interface AttributeExtractor {
 
     AttributeSet fromPath(String path);
 

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class AttributeSet {
 
@@ -37,7 +38,7 @@ public class AttributeSet {
     }
 
     public AttributeSet(Collection<Attribute> attributes) {
-        this(AttributeSet.map(attributes.toArray(new Attribute[attributes.size()])).attributes);
+        this(AttributeSet.map(attributes.toArray(new Attribute[0])).attributes);
     }
 
     public AttributeSet(Map<Key, Attribute> attributes) {
@@ -90,15 +91,13 @@ public class AttributeSet {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         AttributeSet that = (AttributeSet) o;
-
-        return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
+        return Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        return attributes != null ? attributes.hashCode() : 0;
+        return Objects.hash(attributes);
     }
 
     public Attribute getAttribute(String key) {

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeSet.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 import java.util.Arrays;

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeType.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 public enum AttributeType {

--- a/src/main/java/io/fabric8/mockwebserver/crud/AttributeType.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/AttributeType.java
@@ -1,6 +1,5 @@
 package io.fabric8.mockwebserver.crud;
 
 public enum AttributeType {
-	WITH, WITHOUT, EXISTS, NOT_EXISTS
-
+    WITH, WITHOUT, EXISTS, NOT_EXISTS
 }

--- a/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CrudDispatcher extends Dispatcher {
+public class CrudDispatcher<T> extends Dispatcher {
 
     private static final String POST = "POST";
     private static final String PUT = "PUT";
@@ -23,17 +23,17 @@ public class CrudDispatcher extends Dispatcher {
     protected Map<AttributeSet, String> map = new HashMap<>();
 
     protected final Context context;
-    protected final AttributeExtractor attributeExtractor;
+    protected final AttributeExtractor<T> attributeExtractor;
     protected final ResponseComposer responseComposer;
 
-    public CrudDispatcher(Context context, AttributeExtractor attributeExtractor, ResponseComposer responseComposer) {
+    public CrudDispatcher(Context context, AttributeExtractor<T> attributeExtractor, ResponseComposer responseComposer) {
         this.context = context;
         this.attributeExtractor = attributeExtractor;
         this.responseComposer = responseComposer;
     }
 
     @Override
-    public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+    public MockResponse dispatch(RecordedRequest request) {
         String path = request.getPath();
         String method = request.getMethod();
 
@@ -139,7 +139,7 @@ public class CrudDispatcher extends Dispatcher {
     public MockResponse handleDelete(String path) {
         MockResponse response = new MockResponse();
         List<AttributeSet> items = new ArrayList<>();
-        AttributeSet query = attributeExtractor.extract(path);
+        AttributeSet query = attributeExtractor.fromPath(path);
 
         for (Map.Entry<AttributeSet, String> entry : map.entrySet()) {
             if (entry.getKey().matches(query)) {
@@ -161,7 +161,7 @@ public class CrudDispatcher extends Dispatcher {
         return map;
     }
 
-    public AttributeExtractor getAttributeExtractor() {
+    public AttributeExtractor<T> getAttributeExtractor() {
         return attributeExtractor;
     }
 
@@ -172,7 +172,7 @@ public class CrudDispatcher extends Dispatcher {
 
     private String doGet(String path) {
         List<String> items = new ArrayList<>();
-        AttributeSet query = attributeExtractor.extract(path);
+        AttributeSet query = attributeExtractor.fromPath(path);
         for (Map.Entry<AttributeSet, String> entry : map.entrySet()) {
             if (entry.getKey().matches(query)) {
                 items.add(entry.getValue());

--- a/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
@@ -23,8 +23,9 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ public class CrudDispatcher extends Dispatcher {
     private static final String GET = "GET";
     private static final String DELETE = "DELETE";
 
-    protected final Map<AttributeSet, String> map = new HashMap<>();
+    protected final Map<AttributeSet, String> map = new LinkedHashMap<>();
 
     protected final Context context;
     protected final AttributeExtractor attributeExtractor;
@@ -51,9 +52,7 @@ public class CrudDispatcher extends Dispatcher {
     @Override
     public MockResponse dispatch(RecordedRequest request) {
         String path = request.getPath();
-        String method = request.getMethod();
-
-        switch (method.toUpperCase()) {
+        switch (request.getMethod().toUpperCase()) {
             case POST:
                 return handleCreate(path, request.getBody().readUtf8());
             case PUT:
@@ -124,7 +123,12 @@ public class CrudDispatcher extends Dispatcher {
      * @return a MockResponse to be dispatched.
      */
     public MockResponse handleUpdate(String path, String body) {
-        return handleCreate(path, body);
+        final String currentItem = doGet(path);
+        final MockResponse response = handleCreate(path, body);
+        if (currentItem == null) {
+            response.setResponseCode(HttpURLConnection.HTTP_CREATED);
+        }
+        return response;
     }
 
     /**

--- a/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
@@ -17,6 +17,7 @@ package io.fabric8.mockwebserver.crud;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.MockServerException;
 import io.fabric8.zjsonpatch.JsonPatch;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -108,7 +109,7 @@ public class CrudDispatcher extends Dispatcher {
                 response.setResponseCode(202);
                 response.setBody(updatedAsString);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                throw new MockServerException("Exception when handling CRUD patch", e);
             }
 
         }

--- a/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
@@ -39,8 +39,9 @@ public class CrudDispatcher extends Dispatcher {
 
         switch (method.toUpperCase()) {
             case POST:
-            case PUT:
                 return handleCreate(path, request.getBody().readUtf8());
+            case PUT:
+                return handleUpdate(path, request.getBody().readUtf8());
             case PATCH:
                 return handlePatch(path, request.getBody().readUtf8());
             case GET:

--- a/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/CrudDispatcher.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/io/fabric8/mockwebserver/crud/Key.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Key.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 import java.util.Objects;

--- a/src/main/java/io/fabric8/mockwebserver/crud/Key.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Key.java
@@ -1,5 +1,7 @@
 package io.fabric8.mockwebserver.crud;
 
+import java.util.Objects;
+
 public class Key {
 
     private final String name;
@@ -10,22 +12,15 @@ public class Key {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         Key key = (Key) o;
-
-        return name != null ? name.equals(key.name) : key.name == null;
+        return Objects.equals(name, key.name);
     }
 
     @Override
     public int hashCode() {
-        return name != null ? name.hashCode() : 0;
+        return Objects.hash(name);
     }
 
     @Override

--- a/src/main/java/io/fabric8/mockwebserver/crud/ResponseComposer.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/ResponseComposer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 import java.util.Collection;

--- a/src/main/java/io/fabric8/mockwebserver/crud/Value.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Value.java
@@ -4,10 +4,10 @@ public class Value {
 
     private static final String ANY = "*";
 
-    private final String value;
+    private final String val;
 
     public Value(String value) {
-        this.value = value;
+        this.val = value;
     }
 
     @Override
@@ -20,25 +20,25 @@ public class Value {
             return false;
         }
 
-        if (ANY.equals(value)) {
+        if (ANY.equals(val)) {
             return true;
         }
 
         Value key = (Value) o;
 
-        if (ANY.equals(key.value)) {
+        if (ANY.equals(key.val)) {
             return true;
         }
-        return value != null ? value.equals(key.value) : key.value == null;
+        return val != null ? val.equals(key.val) : key.val == null;
     }
 
     @Override
     public int hashCode() {
-        return value != null ? value.hashCode() : 0;
+        return val != null ? val.hashCode() : 0;
     }
 
     @Override
     public String toString() {
-        return value;
+        return val;
     }
 }

--- a/src/main/java/io/fabric8/mockwebserver/crud/Value.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Value.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.mockwebserver.crud;
 
 public class Value {

--- a/src/main/java/io/fabric8/mockwebserver/crud/Value.java
+++ b/src/main/java/io/fabric8/mockwebserver/crud/Value.java
@@ -11,6 +11,7 @@ public class Value {
     }
 
     @Override
+    // TODO: There's a BUG here, equals({val: "*"} is true but might have different hashCode
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/src/main/java/io/fabric8/mockwebserver/dsl/DelayPathable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/DelayPathable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 public interface DelayPathable<T> extends Delayable<Pathable<T>>,

--- a/src/main/java/io/fabric8/mockwebserver/dsl/DelayTimesOrOnceable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/DelayTimesOrOnceable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 public interface DelayTimesOrOnceable<T> extends Delayable<T>, TimesOrOnceable<T> {

--- a/src/main/java/io/fabric8/mockwebserver/dsl/Delayable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Delayable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/io/fabric8/mockwebserver/dsl/Onceable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Onceable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 public interface Onceable<T> {

--- a/src/main/java/io/fabric8/mockwebserver/dsl/Returnable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Returnable.java
@@ -20,9 +20,6 @@ public interface Returnable<T> {
 
   T andReturn(int statusCode, Object content);
 
-  @Deprecated
-  T andReturnChucked(int statusCode, Object... content);
-
   T andReturnChunked(int statusCode, Object... content);
 
 }

--- a/src/main/java/io/fabric8/mockwebserver/dsl/Schedulable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Schedulable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/io/fabric8/mockwebserver/dsl/TimesOnceableOrHttpHeaderable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/TimesOnceableOrHttpHeaderable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 public interface TimesOnceableOrHttpHeaderable<T> extends HttpHeaderable<TimesOnceableOrHttpHeaderable<T>>, TimesOrOnceable<T> {

--- a/src/main/java/io/fabric8/mockwebserver/dsl/TimesOrOnceable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/TimesOrOnceable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 public interface TimesOrOnceable<T> extends Timesable<T>,

--- a/src/main/java/io/fabric8/mockwebserver/dsl/Timesable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/Timesable.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.dsl;
 
 public interface Timesable<T> {

--- a/src/main/java/io/fabric8/mockwebserver/dsl/WebSocketable.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/WebSocketable.java
@@ -22,6 +22,11 @@ public interface WebSocketable<T> {
 
   T andUpgradeToWebSocket();
 
+  /**
+   * @deprecated the provided ScheduledExecutorService is not used, use {@link #andUpgradeToWebSocket()} instead.
+   * The ExecutorService is handled internally by WebSocketSession, external executors are no longer allowed.
+   */
+  @Deprecated
   T andUpgradeToWebSocket(ScheduledExecutorService executor);
 
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
@@ -23,7 +23,6 @@ import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.utils.ResponseProvider;
 import io.fabric8.mockwebserver.utils.ResponseProviders;
 
-import okhttp3.Headers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 

--- a/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
@@ -58,11 +58,7 @@ public class ChunkedResponse implements ServerResponse {
         return bodyProvider;
     }
 
-    @Deprecated
-    public MockResponse toMockResponse() {
-        return toMockResponse(null);
-    }
-
+    @Override
     public MockResponse toMockResponse(RecordedRequest request) {
         MockResponse mockResponse = new MockResponse();
         mockResponse.setHeaders(bodyProvider.getHeaders());
@@ -84,6 +80,7 @@ public class ChunkedResponse implements ServerResponse {
         return sb.toString();
     }
 
+    @Override
     public boolean isRepeatable() {
         return repeatable;
     }

--- a/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/ChunkedResponse.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.internal;
 
 import java.util.List;

--- a/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
@@ -19,6 +19,7 @@ package io.fabric8.mockwebserver.internal;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.MockServerException;
 import io.fabric8.mockwebserver.dsl.Emitable;
 import io.fabric8.mockwebserver.dsl.EventDoneable;
 import io.fabric8.mockwebserver.dsl.Function;
@@ -188,7 +189,7 @@ public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder
             try {
                 return toWebSocketMessage(delay, MAPPER.writeValueAsString(content), toBeRemoved);
             } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
+                throw new MockServerException("Exception when mapping to WebSocketMessage", e);
             }
         }
     }

--- a/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
@@ -63,7 +63,7 @@ public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder
 
     @Override
     public T failure(Object response, Exception e) {
-        return function.apply(new WebSocketSession(context, executor, Collections.<WebSocketMessage>emptyList(), toWebSocketMessage(response), e));
+        return function.apply(new WebSocketSession(context, executor, Collections.emptyList(), toWebSocketMessage(response), e));
     }
 
     @Override
@@ -73,102 +73,84 @@ public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder
 
     @Override
     public Emitable<TimesOrOnceable<EventDoneable<T>>> expect(final Object in) {
-        return new Emitable<TimesOrOnceable<EventDoneable<T>>>() {
+        return event -> new TimesOrOnceable<EventDoneable<T>>() {
             @Override
-            public TimesOrOnceable<EventDoneable<T>> andEmit(final Object event) {
-                return new TimesOrOnceable<EventDoneable<T>>() {
-                    @Override
-                    public EventDoneable<T> always() {
-                        enqueue(in, toWebSocketMessage(event, false));
-                        return InlineWebSocketSessionBuilder.this;
-                    }
+            public EventDoneable<T> always() {
+                enqueue(in, toWebSocketMessage(event, false));
+                return InlineWebSocketSessionBuilder.this;
+            }
 
-                    @Override
-                    public EventDoneable<T> once() {
-                        enqueue(in, toWebSocketMessage(event, true));
-                        return InlineWebSocketSessionBuilder.this;
-                    }
+            @Override
+            public EventDoneable<T> once() {
+                enqueue(in, toWebSocketMessage(event, true));
+                return InlineWebSocketSessionBuilder.this;
+            }
 
-                    @Override
-                    public EventDoneable<T> times(int times) {
-                        for (int i = 0; i < times; i++) {
-                            enqueue(in, toWebSocketMessage(event, true));
-                        }
-                        return InlineWebSocketSessionBuilder.this;
-                    }
-                };
+            @Override
+            public EventDoneable<T> times(int times) {
+                for (int i = 0; i < times; i++) {
+                    enqueue(in, toWebSocketMessage(event, true));
+                }
+                return InlineWebSocketSessionBuilder.this;
             }
         };
     }
 
     @Override
     public Emitable<TimesOrOnceable<EventDoneable<T>>> expectHttpRequest(final String path) {
-        return new Emitable<TimesOrOnceable<EventDoneable<T>>>() {
+        return event -> new TimesOrOnceable<EventDoneable<T>>() {
             @Override
-            public TimesOrOnceable<EventDoneable<T>> andEmit(final Object event) {
-                return new TimesOrOnceable<EventDoneable<T>>() {
-                    @Override
-                    public EventDoneable<T> always() {
-                        enqueueSimpleRequest(new SimpleRequest(path), toWebSocketMessage(event, false));
-                        return InlineWebSocketSessionBuilder.this;
-                    }
+            public EventDoneable<T> always() {
+                enqueueSimpleRequest(new SimpleRequest(path), toWebSocketMessage(event, false));
+                return InlineWebSocketSessionBuilder.this;
+            }
 
-                    @Override
-                    public EventDoneable<T> once() {
-                        enqueueSimpleRequest(new SimpleRequest(path), toWebSocketMessage(event, true));
-                        return InlineWebSocketSessionBuilder.this;
-                    }
+            @Override
+            public EventDoneable<T> once() {
+                enqueueSimpleRequest(new SimpleRequest(path), toWebSocketMessage(event, true));
+                return InlineWebSocketSessionBuilder.this;
+            }
 
-                    @Override
-                    public EventDoneable<T> times(int times) {
-                        for (int i = 0; i < times; i++) {
-                            enqueueSimpleRequest(new SimpleRequest(path), toWebSocketMessage(event, true));
-                        }
-                        return InlineWebSocketSessionBuilder.this;
-                    }
-                };
+            @Override
+            public EventDoneable<T> times(int times) {
+                for (int i = 0; i < times; i++) {
+                    enqueueSimpleRequest(new SimpleRequest(path), toWebSocketMessage(event, true));
+                }
+                return InlineWebSocketSessionBuilder.this;
             }
         };
     }
 
     @Override
     public Emitable<TimesOrOnceable<EventDoneable<T>>> expectSentWebSocketMessage(final Object in) {
-        return new Emitable<TimesOrOnceable<EventDoneable<T>>>() {
+        return event -> new TimesOrOnceable<EventDoneable<T>>() {
             @Override
-            public TimesOrOnceable<EventDoneable<T>> andEmit(final Object event) {
-                return new TimesOrOnceable<EventDoneable<T>>() {
-                    @Override
-                    public EventDoneable<T> always() {
-                        enqueueForSentWebSocketMessage(in, toWebSocketMessage(event, false));
-                        return InlineWebSocketSessionBuilder.this;
-                    }
+            public EventDoneable<T> always() {
+                enqueueForSentWebSocketMessage(in, toWebSocketMessage(event, false));
+                return InlineWebSocketSessionBuilder.this;
+            }
 
-                    @Override
-                    public EventDoneable<T> once() {
-                        enqueueForSentWebSocketMessage(in, toWebSocketMessage(event, true));
-                        return InlineWebSocketSessionBuilder.this;
-                    }
+            @Override
+            public EventDoneable<T> once() {
+                enqueueForSentWebSocketMessage(in, toWebSocketMessage(event, true));
+                return InlineWebSocketSessionBuilder.this;
+            }
 
-                    @Override
-                    public EventDoneable<T> times(int times) {
-                        for (int i = 0; i < times; i++) {
-                            enqueueForSentWebSocketMessage(in, toWebSocketMessage(event, true));
-                        }
-                        return InlineWebSocketSessionBuilder.this;
-                    }
-                };
+            @Override
+            public EventDoneable<T> times(int times) {
+                for (int i = 0; i < times; i++) {
+                    enqueueForSentWebSocketMessage(in, toWebSocketMessage(event, true));
+                }
+                return InlineWebSocketSessionBuilder.this;
             }
         };
     }
 
     @Override
     public Emitable<EventDoneable<T>> waitFor(final long millis) {
-        return new Emitable<EventDoneable<T>>() {
-            @Override
-            public EventDoneable<T> andEmit(Object event) {
-                session.getTimedEvents().add(toWebSocketMessage(millis, event));
-                return InlineWebSocketSessionBuilder.this;
-            }
+        return event -> {
+            session.getTimedEvents().add(toWebSocketMessage(millis, event));
+            return InlineWebSocketSessionBuilder.this;
         };
     }
 

--- a/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
@@ -31,40 +31,30 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder<T>, EventDoneable<T> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final ScheduledExecutorService executor;
     private final Context context;
     private final Function<WebSocketSession, T> function;
     private WebSocketSession session;
 
-    public InlineWebSocketSessionBuilder(Context context, ScheduledExecutorService executor, Function<WebSocketSession, T> function) {
-        this.context = context;
-        this.function = function;
-        this.executor = executor;
-    }
-
     public InlineWebSocketSessionBuilder(Context context, Function<WebSocketSession, T> function) {
         this.context = context;
         this.function = function;
-        this.executor = Executors.newSingleThreadScheduledExecutor();
     }
 
     @Override
     public EventDoneable<T> open(Object... response) {
-        this.session = new WebSocketSession(context, executor, toWebSocketMessages(response), null, null);
+        this.session = new WebSocketSession(toWebSocketMessages(response), null, null);
         return this;
     }
 
 
     @Override
     public T failure(Object response, Exception e) {
-        return function.apply(new WebSocketSession(context, executor, Collections.emptyList(), toWebSocketMessage(response), e));
+        return function.apply(new WebSocketSession(Collections.emptyList(), toWebSocketMessage(response), e));
     }
 
     @Override

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
@@ -16,7 +16,6 @@
 
 package io.fabric8.mockwebserver.internal;
 
-
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -39,7 +38,7 @@ public class MockDispatcher extends Dispatcher {
     }
 
     @Override
-    public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+    public MockResponse dispatch(RecordedRequest request) {
         for (WebSocketSession webSocketSession : webSocketSessions) {
             webSocketSession.dispatch(request);
         }

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
@@ -16,22 +16,22 @@
 
 package io.fabric8.mockwebserver.internal;
 
-import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.HttpMethod;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class MockDispatcher extends Dispatcher {
 
     private final Map<ServerRequest, Queue<ServerResponse>> responses;
-    private final List<WebSocketSession> webSocketSessions = new ArrayList<>();
+    private final Collection<WebSocketSession> webSocketSessions = new ConcurrentLinkedQueue<>();
 
     public MockDispatcher(Map<ServerRequest, Queue<ServerResponse>> responses) {
         this.responses = responses;
@@ -72,4 +72,9 @@ public class MockDispatcher extends Dispatcher {
         return response.toMockResponse(request);
     }
 
+    @Override
+    public void shutdown() {
+        webSocketSessions.forEach(WebSocketSession::shutdown);
+        super.shutdown();
+    }
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockSSLContextFactory.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockSSLContextFactory.java
@@ -17,12 +17,16 @@
 package io.fabric8.mockwebserver.internal;
 
 
+import io.fabric8.mockwebserver.MockServerException;
 import io.fabric8.mockwebserver.utils.SSLUtils;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 
 public class MockSSLContextFactory {
+
+  private MockSSLContextFactory() {
+  }
 
   public static SSLContext create() {
     try {
@@ -31,7 +35,7 @@ public class MockSSLContextFactory {
         "RSA", "");
       return SSLUtils.sslContext(keyManagers, null, true);
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new MockServerException("Exception creating SSLContext", e);
     }
   }
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
@@ -181,9 +181,12 @@ public class MockServerExpectationImpl implements MockServerExpectation {
     return new InlineWebSocketSessionBuilder<>(context, new WebSocketSessionConverter(this));
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public WebSocketSessionBuilder<TimesOnceableOrHttpHeaderable<Void>> andUpgradeToWebSocket(ScheduledExecutorService executor) {
-    return new InlineWebSocketSessionBuilder<>(context, executor, new WebSocketSessionConverter(this));
+    return new InlineWebSocketSessionBuilder<>(context, new WebSocketSessionConverter(this));
   }
 
   @Override

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
@@ -35,7 +35,6 @@ import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.mockwebserver.dsl.Pathable;
 import io.fabric8.mockwebserver.dsl.ReturnOrWebsocketable;
 import io.fabric8.mockwebserver.dsl.TimesOnceableOrHttpHeaderable;
-import io.fabric8.mockwebserver.dsl.TimesOrOnceable;
 import io.fabric8.mockwebserver.dsl.WebSocketSessionBuilder;
 import io.fabric8.mockwebserver.utils.BodyProvider;
 import io.fabric8.mockwebserver.utils.ResponseProvider;
@@ -127,12 +126,6 @@ public class MockServerExpectationImpl implements MockServerExpectation {
   @Override
   public TimesOnceableOrHttpHeaderable<Void> andReply(ResponseProvider<Object> content) {
     return new MockServerExpectationImpl(context, method, path, toString(content), chunksProvider, delay, delayUnit, times, responses);
-  }
-
-  @Override
-  @Deprecated
-  public TimesOnceableOrHttpHeaderable<Void> andReturnChucked(int statusCode, Object... contents) {
-    return andReturnChunked(statusCode, contents);
   }
 
   @Override

--- a/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/MockServerExpectationImpl.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.MockServerException;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.DelayPathable;
@@ -271,7 +272,7 @@ public class MockServerExpectationImpl implements MockServerExpectation {
       try {
         return context.getMapper().writeValueAsString(object);
       } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+        throw new MockServerException("Exception when mapping Object to String", e);
       }
     }
   }

--- a/src/main/java/io/fabric8/mockwebserver/internal/SimpleResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/SimpleResponse.java
@@ -22,7 +22,6 @@ import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.utils.ResponseProvider;
 import io.fabric8.mockwebserver.utils.ResponseProviders;
 
-import okhttp3.Headers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -59,11 +58,7 @@ public class SimpleResponse implements ServerResponse {
     return bodyProvider;
   }
 
-  @Deprecated
-  public MockResponse toMockResponse() {
-    return toMockResponse(null);
-  }
-
+  @Override
   public MockResponse toMockResponse(RecordedRequest request) {
     MockResponse mockResponse = new MockResponse();
     mockResponse.setHeaders(bodyProvider.getHeaders());
@@ -86,6 +81,7 @@ public class SimpleResponse implements ServerResponse {
     return webSocketSession;
   }
 
+  @Override
   public boolean isRepeatable() {
     return repeatable;
   }

--- a/src/main/java/io/fabric8/mockwebserver/internal/SimpleResponse.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/SimpleResponse.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.mockwebserver.internal;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import io.fabric8.mockwebserver.ServerResponse;
@@ -90,21 +91,12 @@ public class SimpleResponse implements ServerResponse {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-
     SimpleResponse that = (SimpleResponse) o;
-
-    if (repeatable != that.repeatable) return false;
-    if (bodyProvider != null ? !bodyProvider.equals(that.bodyProvider) : that.bodyProvider != null) return false;
-    return webSocketSession != null ? webSocketSession.equals(that.webSocketSession) : that.webSocketSession == null;
-
+    return repeatable == that.repeatable && responseDelay == that.responseDelay && Objects.equals(bodyProvider, that.bodyProvider) && Objects.equals(webSocketSession, that.webSocketSession) && responseDelayUnit == that.responseDelayUnit;
   }
 
   @Override
   public int hashCode() {
-    int result = bodyProvider != null ? bodyProvider.hashCode() : 0;
-    result = 31 * result + (webSocketSession != null ? webSocketSession.hashCode() : 0);
-    result = 31 * result + (repeatable ? 1 : 0);
-    return result;
+    return Objects.hash(bodyProvider, webSocketSession, repeatable, responseDelay, responseDelayUnit);
   }
-
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebSocketMessage.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebSocketMessage.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.mockwebserver.internal;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class WebSocketMessage {

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -19,20 +19,22 @@ package io.fabric8.mockwebserver.internal;
 import io.fabric8.mockwebserver.MockServerException;
 import io.fabric8.mockwebserver.dsl.HttpMethod;
 import okhttp3.Response;
-import io.fabric8.mockwebserver.Context;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okhttp3.mockwebserver.RecordedRequest;
 import okio.ByteString;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class WebSocketSession extends WebSocketListener {
 
@@ -40,42 +42,38 @@ public class WebSocketSession extends WebSocketListener {
     private final WebSocketMessage failure;
     private final Exception cause;
 
+    private final Collection<WebSocket> activeSockets = ConcurrentHashMap.newKeySet();
+    private final Collection<UUID> pendingMessages = ConcurrentHashMap.newKeySet();
     private final Map<Object, Queue<WebSocketMessage>> requestEvents = new HashMap<>();
     private final Map<Object, Queue<WebSocketMessage>> sentWebSocketMessagesRequestEvents = new HashMap<>();
     private final Map<SimpleRequest, Queue<WebSocketMessage>> httpRequestEvents = new HashMap<>();
     private final List<WebSocketMessage> timedEvents = new ArrayList<>();
 
-    private final AtomicReference<WebSocket> webSocketRef = new AtomicReference<>();
     private final ScheduledExecutorService executor;
 
-    private final Context context;
-
-    @Override
-    public void onClosing(WebSocket webSocket, int code, String reason) {
-        webSocketRef.get().close(code, reason);
-    }
-
-    public WebSocketSession(Context context, ScheduledExecutorService executor, List<WebSocketMessage> open, WebSocketMessage failure, Exception cause) {
-        this.context = context;
+    public WebSocketSession(List<WebSocketMessage> open, WebSocketMessage failure, Exception cause) {
         this.open = open;
         this.failure = failure;
         this.cause = cause;
-        this.executor = executor;
+        this.executor = Executors.newScheduledThreadPool(1);
+    }
+
+    @Override
+    public void onClosing(WebSocket webSocket, int code, String reason) {
+        webSocket.close(code, reason);
     }
 
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
-        webSocketRef.set(webSocket);
+        activeSockets.add(webSocket);
         //Schedule all timed events
         for (WebSocketMessage msg : open) {
-            send(msg);
+            send(webSocket, msg);
         }
 
         for (WebSocketMessage msg : timedEvents) {
-            send(msg);
+            send(webSocket, msg);
         }
-
-        checkIfShouldClose();
     }
 
     @Override
@@ -86,32 +84,32 @@ public class WebSocketSession extends WebSocketListener {
     @Override
     public void onMessage(WebSocket webSocket, String in) {
         Queue<WebSocketMessage> queue = requestEvents.get(in);
-        send(queue, in);
+        send(webSocket, queue, in);
     }
 
     @Override
     public void onClosed(WebSocket webSocket, int code, String reason) {
+        activeSockets.remove(webSocket);
     }
 
-    private void send(Queue<WebSocketMessage> queue, String in) {
+    private void send(WebSocket ws, Queue<WebSocketMessage> queue, String in) {
         if (queue != null && !queue.isEmpty()) {
             WebSocketMessage msg = queue.peek();
-            send(msg);
+            send(ws, msg);
             if (msg.isToBeRemoved()) {
                 queue.remove();
             }
-            checkIfShouldSendAgain(msg);
-            checkIfShouldClose();
+            checkIfShouldSendAgain(ws, msg);
         } else {
-            webSocketRef.get().close(1002, "Unexpected message:" + in);
+            ws.close(1002, "Unexpected message:" + in);
         }
     }
 
-    private void checkIfShouldSendAgain(WebSocketMessage msg) {
+    private void checkIfShouldSendAgain(WebSocket ws, WebSocketMessage msg) {
         String text = msg.isBinary() ? ByteString.of(msg.getBytes()).utf8() : msg.getBody();
         if (sentWebSocketMessagesRequestEvents.containsKey(text)) {
             Queue<WebSocketMessage> queue = sentWebSocketMessagesRequestEvents.get(text);
-            send(queue, text);
+            send(ws, queue, text);
         }
     }
 
@@ -122,10 +120,10 @@ public class WebSocketSession extends WebSocketListener {
         SimpleRequest keyForAnyMethod = new SimpleRequest(path);
         if (httpRequestEvents.containsKey(key)) {
             Queue<WebSocketMessage> queue = httpRequestEvents.get(key);
-            send(queue, "from http " + path);
+            activeSockets.forEach(ws -> send(ws, queue, "from http " + path));
         } else if (httpRequestEvents.containsKey(keyForAnyMethod)) {
             Queue<WebSocketMessage> queue = httpRequestEvents.get(keyForAnyMethod);
-            send(queue, "from http " + path);
+            activeSockets.forEach(ws -> send(ws, queue, "from http " + path));
         }
     }
 
@@ -157,30 +155,37 @@ public class WebSocketSession extends WebSocketListener {
         return httpRequestEvents;
     }
 
-    private void checkIfShouldClose() {
-        if (requestEvents.isEmpty() && httpRequestEvents.isEmpty() && sentWebSocketMessagesRequestEvents.isEmpty()) {
-            try {
-                executor.shutdown();
-                if (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-                    executor.shutdownNow();
-                }
-                webSocketRef.get().close(1000, "Closing...");
-            } catch (Exception ex) {
-                throw new MockServerException("Exception when shutting down WebSocketSession", ex);
-            }
-        }
-    }
-
-    private void send(final WebSocketMessage message) {
+    private void send(final WebSocket ws, final WebSocketMessage message) {
+        final UUID id = UUID.randomUUID();
+        pendingMessages.add(id);
         executor.schedule(() -> {
-            WebSocket ws = webSocketRef.get();
             if (ws != null) {
                 if (message.isBinary()) {
                     ws.send(ByteString.of(message.getBytes()));
                 } else {
                     ws.send(message.getBody());
                 }
+                pendingMessages.remove(id);
             }
+            closeActiveSocketsIfApplicable();
         }, message.getDelay(), TimeUnit.MILLISECONDS);
+    }
+
+    public void closeActiveSocketsIfApplicable() {
+        if (pendingMessages.isEmpty() && requestEvents.isEmpty() && httpRequestEvents.isEmpty()
+          && sentWebSocketMessagesRequestEvents.isEmpty()) {
+            activeSockets.forEach(ws -> ws.close(1000, "Closing..."));
+        }
+    }
+
+    public void shutdown() {
+        try {
+            executor.shutdown();
+            if (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            throw MockServerException.launderThrowable(e);
+        }
     }
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.mockwebserver.internal;
 
+import io.fabric8.mockwebserver.MockServerException;
 import io.fabric8.mockwebserver.dsl.HttpMethod;
 import okhttp3.Response;
 import io.fabric8.mockwebserver.Context;
@@ -165,7 +166,7 @@ public class WebSocketSession extends WebSocketListener {
                 }
                 webSocketRef.get().close(1000, "Closing...");
             } catch (Exception ex) {
-                throw new RuntimeException(ex);
+                throw new MockServerException("Exception when shutting down WebSocketSession", ex);
             }
         }
     }

--- a/src/main/java/io/fabric8/mockwebserver/utils/BodyProvider.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/BodyProvider.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.mockwebserver.utils;
 

--- a/src/main/java/io/fabric8/mockwebserver/utils/CertUtils.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/CertUtils.java
@@ -39,9 +39,11 @@ import java.security.spec.RSAPrivateCrtKeySpec;
 
 public class CertUtils {
 
+    private CertUtils() {}
+
     public static InputStream getInputStreamFromDataOrFile(String data, String file) throws FileNotFoundException {
         if (data != null) {
-            byte[] bytes = null;
+            final byte[] bytes;
             ByteString decoded = ByteString.decodeBase64(data);
             if (decoded != null) {
                 bytes = decoded.toByteArray();
@@ -95,8 +97,7 @@ public class CertUtils {
     // http://oauth.googlecode.com/svn/code/java/
     // All credits to belong to them.
     private static byte[] decodePem(InputStream keyInputStream) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(keyInputStream));
-        try {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(keyInputStream))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (line.contains("-----BEGIN ")) {
@@ -104,8 +105,6 @@ public class CertUtils {
                 }
             }
             throw new IOException("PEM is invalid: no begin marker");
-        } finally {
-            reader.close();
         }
     }
 

--- a/src/main/java/io/fabric8/mockwebserver/utils/Closeables.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/Closeables.java
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.utils;
 
 import java.io.Closeable;

--- a/src/main/java/io/fabric8/mockwebserver/utils/PKCS1Util.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/PKCS1Util.java
@@ -59,9 +59,9 @@ class PKCS1Util {
 
     static class DerParser {
 
-        private InputStream in;
+        private final InputStream in;
 
-        DerParser(byte[] bytes) throws IOException {
+        DerParser(byte[] bytes) {
             this.in = new ByteArrayInputStream(bytes);
         }
 

--- a/src/main/java/io/fabric8/mockwebserver/utils/ResponseProvider.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/ResponseProvider.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.mockwebserver.utils;
 

--- a/src/main/java/io/fabric8/mockwebserver/utils/ResponseProviders.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/ResponseProviders.java
@@ -19,7 +19,7 @@ import okhttp3.Headers;
 import okhttp3.mockwebserver.RecordedRequest;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +28,7 @@ import java.util.Map;
  */
 public class ResponseProviders {
 
+    private ResponseProviders() {}
 
     public static <R> ResponseProvider<R> of(int statusCode, R element) {
         if (element != null) {
@@ -81,22 +82,16 @@ public class ResponseProviders {
 
     private static class FixedResponseProvider<T> implements ResponseProvider<T> {
 
-        private int statusCode;
-        private T element;
-        private Headers headers = new Headers.Builder().build();
+        private final int statusCode;
+        private final T element;
+        private Headers headers;
 
         public FixedResponseProvider(int statusCode, T element) {
-            this(statusCode, element, new HashMap<String, String>());
+            this(statusCode, element, Collections.emptyMap());
         }
 
         public FixedResponseProvider(int statusCode, T element, Map<String, String> headers) {
-            this.statusCode = statusCode;
-            this.element = element;
-            Headers.Builder builder = new Headers.Builder();
-            for (Map.Entry<String, String> entry : headers.entrySet()) {
-                builder.set(entry.getKey(), entry.getValue());
-            }
-            this.headers = builder.build();
+            this(statusCode, element, toHeaders(headers));
         }
 
         public FixedResponseProvider(int statusCode, T element, Headers headers) {
@@ -139,6 +134,14 @@ public class ResponseProviders {
         @Override
         public int hashCode() {
             return element != null ? element.hashCode() : 0;
+        }
+
+        private static Headers toHeaders(Map<String, String> headers) {
+            final Headers.Builder builder = new Headers.Builder();
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                builder.set(entry.getKey(), entry.getValue());
+            }
+            return builder.build();
         }
     }
 

--- a/src/main/java/io/fabric8/mockwebserver/utils/ResponseProviders.java
+++ b/src/main/java/io/fabric8/mockwebserver/utils/ResponseProviders.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.mockwebserver.utils;
 

--- a/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerCrudTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerCrudTest.groovy
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.fabric8.mockwebserver.crud.CrudDispatcher
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.mockwebserver.MockWebServer
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DefaultMockServerCrudTest extends Specification {
+
+  DefaultMockServer server
+
+  @Shared
+  def client = new OkHttpClient()
+
+  @Shared
+  def mapper = new ObjectMapper()
+
+  def setup() {
+    server = new DefaultMockServer(new Context(), new MockWebServer(), new HashMap<>(),
+        new CrudDispatcher(new Context(), new UserAttributeExtractor(), new JsonResponseComposer()), false)
+    server.start()
+  }
+
+  def cleanup() {
+    server.shutdown()
+  }
+
+  def "get /, with empty store, should return 404"() {
+    when:
+    def result = client.newCall(new Request.Builder().url(server.url("/")).build()).execute()
+
+    then:
+    assert result.code() == 404
+    assert result.body().string() == ""
+  }
+
+  def "get /, with one item, should return item"() {
+    given:
+    client.newCall(new Request.Builder().url(server.url("/")).post(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(1L, "user", true)))).build()).
+        execute()
+
+    when:
+    def result = client.newCall(new Request.Builder().url(server.url("/")).build()).execute()
+
+    then:
+    assert result.code() == 200
+    assert result.body().string() == "{\"id\":1,\"username\":\"user\",\"enabled\":true}"
+  }
+
+  def "get /, with multiple items, should return array"() {
+    given:
+    client.newCall(new Request.Builder().url(server.url("/")).post(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(1L, "user", true)))).build()).
+        execute()
+    client.newCall(new Request.Builder().url(server.url("/")).post(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(2L, "user-2", true)))).build()).
+        execute()
+
+    when:
+    def result = client.newCall(new Request.Builder().url(server.url("/")).build()).execute()
+
+    then:
+    assert result.code() == 200
+    assert result.body().string() ==
+        "[{\"id\":1,\"username\":\"user\",\"enabled\":true},{\"id\":2,\"username\":\"user-2\",\"enabled\":true}]"
+  }
+
+  def "get /1, with existent item, should return item"() {
+    given:
+    client.newCall(new Request.Builder().url(server.url("/")).post(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(1L, "user", true)))).build()).
+        execute()
+    client.newCall(new Request.Builder().url(server.url("/")).post(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(2L, "user-2", true)))).build()).
+        execute()
+
+    when:
+    def result = client.newCall(new Request.Builder().url(server.url("/1")).build()).execute()
+
+    then:
+    assert result.code() == 200
+    assert result.body().string() == "{\"id\":1,\"username\":\"user\",\"enabled\":true}"
+  }
+
+  def "put /1, with missing item, should create item"() {
+    when:
+    def result = client.newCall(new Request.Builder().url(server.url("/1")).put(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(1L, "user-replaced", true)))).build()).
+        execute()
+
+    then:
+    assert result.code() == 201
+    assert result.body().string() == "{\"id\":1,\"username\":\"user-replaced\",\"enabled\":true}"
+  }
+
+  def "put /1, with existent item, should replace item"() {
+    given:
+    client.newCall(new Request.Builder().url(server.url("/")).post(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(1L, "user", true)))).build()).
+        execute()
+
+    when:
+    def result = client.newCall(new Request.Builder().url(server.url("/1")).put(
+        RequestBody.create(MediaType.parse("application/json"),
+            mapper.writeValueAsString(new User(1L, "user-replaced", true)))).build()).
+        execute()
+
+    then:
+    assert result.code() == 202
+    assert result.body().string() == "{\"id\":1,\"username\":\"user-replaced\",\"enabled\":true}"
+    def item = client.newCall(new Request.Builder().url(server.url("/1")).build()).execute()
+    assert item.body().string() == "{\"id\":1,\"username\":\"user-replaced\",\"enabled\":true}"
+  }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerHttpsTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerHttpsTest.groovy
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver
+
+import okhttp3.OkHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DefaultMockServerHttpsTest extends Specification {
+
+  DefaultMockServer server
+
+  @Shared
+  OkHttpClient client = new OkHttpClient()
+
+  def setup() {
+    server = new DefaultMockServer(true)
+    server.start()
+  }
+
+  def cleanup() {
+    server.shutdown()
+  }
+
+  def "url, with path, returns URL with HTTPS protocol"() {
+    when:
+    def result = server.url("/")
+
+    then:
+    assert result.startsWith("https://")
+  }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver
 
 import io.fabric8.mockwebserver.utils.ResponseProvider

--- a/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
+import java.util.stream.IntStream
+
+class DefaultMockServerWebSocketTest extends Specification {
+
+  DefaultMockServer server
+
+  @Shared
+  OkHttpClient client = new OkHttpClient()
+
+  def setup() {
+    server = new DefaultMockServer()
+    server.start()
+  }
+
+  def cleanup() {
+    server.shutdown()
+  }
+
+  def "andUpgradeToWebSocket, with configured events, should emit events"() {
+    given:
+    server.expect()
+        .withPath("/websocket")
+        .andUpgradeToWebSocket().open().waitFor(10L).andEmit("A text message").done().always()
+    def future = new CompletableFuture()
+    when:
+    def ws = client.newWebSocket(new Request.Builder().url(server.url("/websocket")).build(), new WebSocketListener() {
+      @Override
+      void onMessage(WebSocket webSocket, String text) {
+        future.complete(text)
+      }
+    })
+    then:
+    assert future.get(100L, TimeUnit.MILLISECONDS) == "A text message"
+    cleanup:
+    ws.close(1000, "Test finished")
+  }
+
+  def "andUpgradeToWebSocket, with configured events, should emit onClose when done"() {
+    given:
+    server.expect()
+        .withPath("/websocket")
+        .andUpgradeToWebSocket().open().immediately().andEmit("event").done().always()
+    def future = new CompletableFuture()
+    when:
+    def ws = client.newWebSocket(new Request.Builder().url(server.url("/websocket")).build(), new WebSocketListener() {
+      @Override
+      void onClosing(WebSocket webSocket, int code, String reason) {
+        future.complete(reason)
+      }
+    })
+    then:
+    assert future.get(100L, TimeUnit.MILLISECONDS) == "Closing..."
+  }
+
+  // https://github.com/fabric8io/mockwebserver/pull/66#issuecomment-944289335
+  def "andUpgradeToWebSocket, with multiple upgrades, should emit events for all websocket listeners"() {
+    given:
+    server.expect()
+        .withPath("/websocket")
+        .andUpgradeToWebSocket().open().waitFor(10L).andEmit("A text message").done().always()
+    def latch = new CountDownLatch(15)
+    def wsListener = new WebSocketListener() {
+      @Override
+      void onMessage(WebSocket webSocket, String text) {
+        latch.countDown()
+      }
+    }
+    when:
+    def wss = IntStream.range(0, 15).mapToObj(i ->
+        client.newWebSocket(new Request.Builder().url(server.url("/websocket")).build(), wsListener)
+    ).collect(Collectors.toList())
+    then:
+    assert latch.await(10000L, TimeUnit.MILLISECONDS)
+    cleanup:
+    wss.forEach(ws -> ws.close(1000, "Test finished"))
+  }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/JsonResponseComposer.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/JsonResponseComposer.groovy
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver
+
+import io.fabric8.mockwebserver.crud.ResponseComposer
+
+import java.util.stream.Collectors
+
+class JsonResponseComposer implements ResponseComposer {
+  @Override
+  String compose(Collection<String> items) {
+    return "[" + items.stream().collect(Collectors.joining(",")) + "]"
+  }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/MockServerExceptionTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/MockServerExceptionTest.groovy
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver
+
+import spock.lang.Specification
+
+class MockServerExceptionTest extends Specification {
+
+  def "launderThrowable, with null, should throw MockServerException"() {
+    when:
+    MockServerException.launderThrowable(null)
+    then:
+    def result = thrown(MockServerException)
+    assert result.getMessage() == "An error has occurred."
+    assert result.getCause() == null
+  }
+
+  def "launderThrowable, with checked exception, should throw MockServerException"() {
+    when:
+    MockServerException.launderThrowable(new Exception("I'm checked"))
+    then:
+    def result = thrown(MockServerException)
+    assert result.getMessage() == "An error has occurred."
+    assert result.getCause().getClass() == Exception
+    assert result.getCause().getMessage() == "I'm checked"
+  }
+
+  def "launderThrowable, with unchecked exception, should throw MockServerException"() {
+    when:
+    def result = MockServerException.launderThrowable(new RuntimeException("I'm unchecked"))
+    then:
+    assert result.getMessage() == "I'm unchecked"
+    assert result.getClass() != MockServerException
+  }
+
+  def "launderThrowable, with Error, should not be handled"() {
+    when:
+    MockServerException.launderThrowable(new Error("I'm an Error"))
+    then:
+    def result = thrown(Error)
+    assert result.getMessage() == "I'm an Error"
+  }
+
+  def "launderThrowable, with Interrupted Exception, should re-interrupt"() {
+    when:
+    MockServerException.launderThrowable(new InterruptedException("I'm interrupted"))
+    then:
+    assert Thread.currentThread().isInterrupted()
+    def result = thrown(MockServerException)
+    assert result.getMessage() == "An error has occurred."
+  }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/User.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/User.groovy
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License")
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver
 
 import com.fasterxml.jackson.annotation.JsonInclude

--- a/src/test/groovy/io/fabric8/mockwebserver/UserAttributeExtractor.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/UserAttributeExtractor.groovy
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.fabric8.mockwebserver.crud.Attribute
+import io.fabric8.mockwebserver.crud.AttributeExtractor
+import io.fabric8.mockwebserver.crud.AttributeSet
+
+class UserAttributeExtractor implements AttributeExtractor {
+
+  static def mapper = new ObjectMapper()
+
+  @Override
+  AttributeSet fromPath(String path) {
+    if (path.trim().isBlank() || path.trim() == "/") {
+      return new AttributeSet();
+    }
+    return new AttributeSet(new Attribute("id", path.substring(1)))
+  }
+
+  @Override
+  AttributeSet fromResource(String resource) {
+    def user = mapper.readValue(resource, User)
+    return new AttributeSet(new Attribute("id", user.getId().toString()))
+  }
+}

--- a/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.crud
 
 import spock.lang.Specification

--- a/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeTest.groovy
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.crud
 
 import spock.lang.Specification

--- a/src/test/groovy/io/fabric8/mockwebserver/crud/CrudDispatcherTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/crud/CrudDispatcherTest.groovy
@@ -52,16 +52,6 @@ class CrudDispatcherTest extends Specification {
         AttributeSet fromResource(String resource) {
             return null
         }
-
-        @Override
-        AttributeSet extract(String path) {
-            return fromPath(path)
-        }
-
-        @Override
-        AttributeSet extract(Object object) {
-            return fromResource(object)
-        }
     }
 
     ResponseComposer composer = new ResponseComposer() {

--- a/src/test/groovy/io/fabric8/mockwebserver/crud/CrudDispatcherTest.groovy
+++ b/src/test/groovy/io/fabric8/mockwebserver/crud/CrudDispatcherTest.groovy
@@ -1,19 +1,18 @@
-/*
- *   Copyright (C) 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *           http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.crud
 
 import io.fabric8.mockwebserver.Context


### PR DESCRIPTION
- Created the base MockServer interface that now exposes most of the underlying MockWebServer methods required for test assertions
- Moved downstream `getLastRequest` method to MockServer + added cache behavior
- Updated dependencies
- Refactored code and removed bugs + smells
- CRUD dispatcher now handles PUT independently of POST
- Added more test coverage

/cc @shawkins Most of the things needed downstream have been exposed. I'm not sure if I may be leaving something out.