### PR TITLE
#71 Add closing message to websocket

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,16 @@ To support mock of web sockets this wrapper allows you to either specify a ``req
                     .waitFor(1500).andEmit("root - DELETED")
                 .done()
                 .once()
+                
+#### Closing Web Socket messages ####
+
+        server.expect().withPath("/api/v1/users/watch")
+                .andUpgradeToWebSocket()
+                .open()
+                    .waitFor(1000).andEmit("root - CREATED")
+                    .waitFor(1500).andEmit(new WebsocketCloseReason(1000, "Bye bye"))
+                .done()
+                .once()
 
 ### CRUD Mocking ###
 

--- a/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/InlineWebSocketSessionBuilder.java
@@ -13,24 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.fabric8.mockwebserver.internal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.MockServerException;
-import io.fabric8.mockwebserver.dsl.Emitable;
-import io.fabric8.mockwebserver.dsl.EventDoneable;
-import io.fabric8.mockwebserver.dsl.Function;
-import io.fabric8.mockwebserver.dsl.TimesOrOnceable;
-import io.fabric8.mockwebserver.dsl.WebSocketSessionBuilder;
+import io.fabric8.mockwebserver.dsl.*;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 
 public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder<T>, EventDoneable<T> {
 
@@ -171,7 +162,10 @@ public class InlineWebSocketSessionBuilder<T> implements WebSocketSessionBuilder
     }
 
     private WebSocketMessage toWebSocketMessage(Long delay, Object content, Boolean toBeRemoved) {
-        if (content instanceof String) {
+        if (content instanceof WebsocketCloseReason) {
+            WebsocketCloseReason closeReason = (WebsocketCloseReason) content;
+            return new WebSocketMessage(delay, closeReason.getReason(), toBeRemoved, closeReason.getCode());
+        } else if (content instanceof String) {
             return new WebSocketMessage(delay, (String) content, toBeRemoved);
         } else if (content instanceof WebSocketMessage) {
             return (WebSocketMessage) content;

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebSocketMessage.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebSocketMessage.java
@@ -23,40 +23,50 @@ public class WebSocketMessage {
     private final byte[] body;
     private final boolean toBeRemoved;
     private final boolean binary;
+    private final Integer closingReason;
 
     public WebSocketMessage(String body) {
         this(0L, body, true);
     }
 
     public WebSocketMessage(byte[] body) {
-        this(0L, body, true, true);
+        this(0L, body, true, true, null);
     }
 
     public WebSocketMessage(String body, boolean toBeRemoved) {
-        this(0L, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, false);
+        this(0L, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, false, null);
     }
 
     public WebSocketMessage(byte[] body, boolean toBeRemoved) {
-        this(0L, body, toBeRemoved, true);
+        this(0L, body, toBeRemoved, true, null);
     }
 
     public WebSocketMessage(Long delay, String body, boolean toBeRemoved) {
-        this(delay, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, false);
+        this(delay, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, false, null);
     }
 
     public WebSocketMessage(Long delay, byte[] body, boolean toBeRemoved) {
-        this(delay, body, toBeRemoved, true);
+        this(delay, body, toBeRemoved, true, null);
+    }
+    
+    public WebSocketMessage(Long delay, String body, boolean toBeRemoved, Integer closingReason) {
+	      this(delay, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, false, closingReason);
+	  }
+
+	  public WebSocketMessage(Long delay, byte[] body, boolean toBeRemoved, Integer closingReason) {
+	      this(delay, body, toBeRemoved, true, closingReason);
+	  }
+
+    public WebSocketMessage(Long delay, String body, boolean toBeRemoved, boolean binary, Integer closingReason) {
+        this(delay, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, binary, closingReason);
     }
 
-    public WebSocketMessage(Long delay, String body, boolean toBeRemoved, boolean binary) {
-        this(delay, body.getBytes(StandardCharsets.UTF_8), toBeRemoved, binary);
-    }
-
-    public WebSocketMessage(Long delay, byte[] body, boolean toBeRemoved, boolean binary) {
+    public WebSocketMessage(Long delay, byte[] body, boolean toBeRemoved, boolean binary, Integer closingReason) {
         this.delay = delay;
         this.body = body;
         this.toBeRemoved = toBeRemoved;
         this.binary = binary;
+        this.closingReason = closingReason;
     }
 
     public Long getDelay() {
@@ -78,4 +88,8 @@ public class WebSocketMessage {
     public boolean isBinary() {
         return binary;
     }
+    
+    public Integer getClosingReason() {
+      return closingReason;
+  }
 }

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -24,6 +24,7 @@ import okhttp3.WebSocketListener;
 import okhttp3.mockwebserver.RecordedRequest;
 import okio.ByteString;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -161,7 +162,13 @@ public class WebSocketSession extends WebSocketListener {
         pendingMessages.add(id);
         executor.schedule(() -> {
             if (ws != null) {
-                if (message.isBinary()) {
+                if (message.getClosingReason() != null) {
+                    if (message.isBinary()) {
+                        ws.close(message.getClosingReason(), new String(message.getBytes(), StandardCharsets.UTF_8));
+                    } else {
+                        ws.close(message.getClosingReason(), message.getBody());
+                    }
+                } else if (message.isBinary()) {
                     ws.send(ByteString.of(message.getBytes()));
                 } else {
                     ws.send(message.getBody());

--- a/src/main/java/io/fabric8/mockwebserver/internal/WebsocketCloseReason.java
+++ b/src/main/java/io/fabric8/mockwebserver/internal/WebsocketCloseReason.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.mockwebserver.internal;
+
+public class WebsocketCloseReason {
+
+    private final int code;
+    private final String reason;
+
+    public WebsocketCloseReason(int code, String reason) {
+        super();
+        this.code = code;
+        this.reason = reason;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+}


### PR DESCRIPTION
Reference: https://github.com/fabric8io/mockwebserver/issues/71

Purpose is to be able to send a closing message to the websocket.
When running a kubernetes exec, a `io.fabric8.kubernetes.api.model.Status` is sent (ref: https://github.com/fabric8io/kubernetes-client/issues/3793)

This allows to write:

```
.waitFor(1500).andEmit(new WebsocketCloseReason(1000, "json representation of the status"))
```
