### PR TITLE
Add `OPTIONS` to HttpMethod

### DIFF
--- a/src/main/java/io/fabric8/mockwebserver/dsl/HttpMethod.java
+++ b/src/main/java/io/fabric8/mockwebserver/dsl/HttpMethod.java
@@ -23,6 +23,7 @@ public enum  HttpMethod {
     PUT,
     PATCH,
     DELETE,
+    OPTIONS,
     ANY
 
 }


### PR DESCRIPTION
`HttpMethod` does not have the standard [OPTIONS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS) which can be used CORS and HTTP/2 Upgrade.
https://datatracker.ietf.org/doc/html/rfc7540#section-3.2

> an OPTIONS request can be used to perform the upgrade to
> HTTP/2, at the cost of an additional round trip.